### PR TITLE
Remove Fox in CI.

### DIFF
--- a/.github/workflows/ci-github-actions.yaml
+++ b/.github/workflows/ci-github-actions.yaml
@@ -35,7 +35,7 @@ jobs:
         run: |
           mkdir build
           cd build 
-          cmake -DCMAKE_C_COMPILER=mpicc -DCMAKE_Fortran_COMPILER=mpif90 -DQE_ENABLE_PLUGINS=pw2qmcpack -DQE_ENABLE_FOX=ON ..
+          cmake -DCMAKE_C_COMPILER=mpicc -DCMAKE_Fortran_COMPILER=mpif90 -DQE_ENABLE_PLUGINS=pw2qmcpack ..
 
       - name: Build q-e
         working-directory: ./q-e/build


### PR DESCRIPTION
The commit of pw2qmcpack in QE upstream has been updated. No need of Fox in CI.